### PR TITLE
:recycle: redis 오류 해결

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
             <version>20180813</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/t2m/g2nee/auth/adaptor/MemberAdaptor.java
+++ b/src/main/java/com/t2m/g2nee/auth/adaptor/MemberAdaptor.java
@@ -47,9 +47,9 @@ public class MemberAdaptor {
         );
     }
 
-    public ResponseEntity<Boolean> login(MemberLoginDTO memberLoginDTO){
+    public ResponseEntity<Boolean> login(MemberLoginDTO memberLoginDTO) {
         HttpHeaders headers = new HttpHeaders();
-        HttpEntity<MemberLoginDTO> entity = new HttpEntity<>(memberLoginDTO,headers);
+        HttpEntity<MemberLoginDTO> entity = new HttpEntity<>(memberLoginDTO, headers);
 
         return restTemplate.exchange(
                 gateWayConfig.getGatewayUrl() + "shop/member/login",

--- a/src/main/java/com/t2m/g2nee/auth/config/RedisConfig.java
+++ b/src/main/java/com/t2m/g2nee/auth/config/RedisConfig.java
@@ -1,9 +1,7 @@
 package com.t2m.g2nee.auth.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.t2m.g2nee.auth.properties.RedisProperties;
-import org.springframework.beans.factory.BeanClassLoaderAware;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -12,7 +10,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.security.jackson2.SecurityJackson2Modules;
 
 /**
  * Redis 연결 ,Spring Security에선 JSON데이터 처리
@@ -24,8 +21,8 @@ import org.springframework.security.jackson2.SecurityJackson2Modules;
 @Configuration
 public class RedisConfig {
 
-
-   RedisProperties redisProperties = new RedisProperties();
+    @Autowired
+    RedisProperties redisProperties;
 
 
     @Bean

--- a/src/main/java/com/t2m/g2nee/auth/config/SecurityConfig.java
+++ b/src/main/java/com/t2m/g2nee/auth/config/SecurityConfig.java
@@ -103,14 +103,6 @@ public class SecurityConfig {
         http
                 .httpBasic((auth) -> auth.disable());
 
-
-//        http
-//                .authorizeHttpRequests((auth)-> auth
-//                        .antMatchers("/auth/login").permitAll()
-//                        .antMatchers("/auth/reissue").permitAll()
-//                        .anyRequest().authenticated());
-
-//
         http.logout()
                 .logoutUrl("/auth/logout")
                 .logoutSuccessUrl("/auth/login");

--- a/src/main/java/com/t2m/g2nee/auth/dto/member/MemberInfoRequestDTO.java
+++ b/src/main/java/com/t2m/g2nee/auth/dto/member/MemberInfoRequestDTO.java
@@ -2,15 +2,15 @@ package com.t2m.g2nee.auth.dto.member;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * shop에서 멤버 정보 받아올 DTO
  */
 
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class MemberInfoRequestDTO {
 
-    private  String username;
+    private String username;
+
 }

--- a/src/main/java/com/t2m/g2nee/auth/dto/member/MemberInfoResponseDTO.java
+++ b/src/main/java/com/t2m/g2nee/auth/dto/member/MemberInfoResponseDTO.java
@@ -1,18 +1,14 @@
 package com.t2m.g2nee.auth.dto.member;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Required;
 
 
 /**
  * 토큰 반환 DTO클래스
  */
 @Getter
-@RequiredArgsConstructor
 @NoArgsConstructor
 public class MemberInfoResponseDTO {
     private Long memberId;

--- a/src/main/java/com/t2m/g2nee/auth/properties/RedisProperties.java
+++ b/src/main/java/com/t2m/g2nee/auth/properties/RedisProperties.java
@@ -3,7 +3,6 @@ package com.t2m.g2nee.auth.properties;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.stereotype.Component;
@@ -13,20 +12,16 @@ import org.springframework.stereotype.Component;
 @ConstructorBinding
 @RequiredArgsConstructor
 @Component
-@ConfigurationProperties(prefix="g2nee.redis")
+@ConfigurationProperties(prefix = "g2nee.redis")
 public class RedisProperties {
 
-    @Value("${host}")
-    private String host;
+    String host;
 
-    @Value("${port}")
-    private int port;
+    int port;
 
-    @Value("${password}")
-    private String password;
+    String password;
 
-    @Value("${database}")
-    private int database;
+    int database;
 
 
 }


### PR DESCRIPTION
## #️⃣Related Issue

- application.properties의 값들을 불러올때 @Value방식과 @ConfigurationProperties가 있는데 @ConfigurationProperties처리를 해주게 되면 prefix뒤에 단어와 변수를 속성과 맞춰 매핑을 해줍니다. 

- RedisConfig에서 RedisProperties의 값들을 생성자로 생성해주어 값들이 제대로 안들어가는 현상을 @Autowired 로 해결하였습니다.

## 📝Work Detail

- @Value 어노테이션 삭제
- RedisConfig의 RedisProperties @Autowired로 주입
- properties에서 오토컴플릿을 지원하기 위한 dependency도 추가였습니다.
```java
<dependency>
	<groupId>org.springframework.boot</groupId>
	<artifactId>spring-boot-configuration-processor</artifactId>
	<optional>true</optional>
</dependency>
```
